### PR TITLE
Fixed Buffstacking Bug 

### DIFF
--- a/eqgame_dll/eqgame.h
+++ b/eqgame_dll/eqgame.h
@@ -27,9 +27,8 @@ void SendCustomSpawnAppearanceMessage(unsigned __int16 feature_id, unsigned __in
 // Song Window Support
 __declspec(dllexport) class CShortBuffWindow* GetShortDurationBuffWindow();
 
-struct _EQBUFFINFO* GetStartBuffArray(class CBuffWindow* window);
-int GetStartBuffIndex(class CBuffWindow* window);
-void SetTemporaryBuffOffset(int offset);
+struct _EQBUFFINFO* GetStartBuffArray(bool songs_buffs);
+void MakeGetBuffReturnSongs(bool enabled);
 
 /*
 voidpf eqemu_alloc_func(voidpf opaque, uInt items, uInt size);

--- a/eqgame_dll/eqmac_functions.h
+++ b/eqgame_dll/eqmac_functions.h
@@ -322,8 +322,8 @@ public:
 	static inline bool RemoveMyAffect(void* player, __int16 buffslot) {
 		return reinterpret_cast<char(__thiscall*)(void*, __int16)>(0x4D0337)(player, buffslot);
 	}
-	static inline int CalcSpellEffectValue(void* player, EQSPELLINFO* spell, BYTE casterLevel, BYTE effectIndex, int v5) {
-		return reinterpret_cast<int(__thiscall*)(void*, EQSPELLINFO*, BYTE, BYTE, int)>(0x004C657D)(player, spell, casterLevel, effectIndex, v5);
+	static inline short CalcSpellEffectValue(void* player, EQSPELLINFO* spell, BYTE casterLevel, BYTE effectIndex, _EQBUFFINFO* optional_buff) {
+		return reinterpret_cast<short(__thiscall*)(void*, EQSPELLINFO*, BYTE, BYTE, _EQBUFFINFO*)>(0x004C657D)(player, spell, casterLevel, effectIndex, optional_buff);
 	}
 	static inline EQBUFFINFO* GetBuff(void* player, __int16 buffslot) {
 		return reinterpret_cast<_EQBUFFINFO * (__thiscall*)(void*, __int16)>(0x004C465A)(player, buffslot);


### PR DESCRIPTION
- Fixed Buffstacking bug.
  - Was a minor error due to a wrong function signature when calling an EQ method. Was using `int` return type instead of `short`. Which caused the values to look very wrong when we did the math to see which was 'stronger'. This is now fixed.
- Formatting / Readability / ID check cleanup.
- Made `GetBuff(slot)` hook safer with how it handles buff offset, if for some reason Zeal/Dll hooks execute in an unexpected order.

# Tested
- [x] SoW overwrites JBoots
- [x] Nexona (Stream of Acid) overwrites Jboots / SoW / Fungal Regrowth / etc..
- [x] Avatar overwrites Primal Essence