### PR TITLE
Improve race support

### DIFF
--- a/eqgame_dll/eqgame.cpp
+++ b/eqgame_dll/eqgame.cpp
@@ -5244,7 +5244,8 @@ void CheckClientMiniMods()
 		UseClassicFrogloks = true;
 		UseLuclinFrogloks = false;
 		PutCustomRaceData(330, 0, "FKM", "");
-		PutCustomRaceData(330, 1, "FKF", "FKM");
+		// PutCustomRaceData(330, 1, "FKF", "FKM"); // TODO: We don't have FKF created yet. Use FKM for now.
+		PutCustomRaceData(330, 1, "FKM", "");
 		PutCustomRaceData(330, 2, "FKM", "");
 	}
 	else if (strcmp(szResult, "NONE") == 0) // Not found
@@ -5252,7 +5253,8 @@ void CheckClientMiniMods()
 		UseClassicFrogloks = true;
 		UseLuclinFrogloks = false;
 		PutCustomRaceData(330, 0, "FKM", "");
-		PutCustomRaceData(330, 1, "FKF", "FKM");
+		// PutCustomRaceData(330, 1, "FKF", "FKM"); TODO: We don't have FKF created yet. Use FKM for now.
+		PutCustomRaceData(330, 1, "FKM", "");
 		PutCustomRaceData(330, 2, "FKM", "");
 		WritePrivateProfileStringA_tramp("Defaults", "UseLuclinFroglok", "FALSE", "./eqclient.ini");
 	}

--- a/eqgame_dll/eqgame.cpp
+++ b/eqgame_dll/eqgame.cpp
@@ -1921,14 +1921,29 @@ bool isFRM_FRF(char* str)
 	return str && str[0] == 'F' && str[1] == 'R' && (str[2] == 'M' || str[2] == 'F');
 }
 
+bool isChest(char* str)
+{
+	return strncmp(&str[3], "CH", 2) == 0;
+}
+
+bool isLeg(char* str)
+{
+	return strncmp(&str[3], "LG", 2) == 0;
+}
+
+bool isWrist(char* str)
+{
+	return strncmp(&str[3], "FA", 2) == 0;
+}
+
 bool isRobe(char* str)
 {
-	return strncmp(&str[3], "CH1", 3) == 0 && str[6] >= '0' && str[6] <= '6';
+	return str[5] == '1' && str[6] >= '0' && str[6] <= '6';
 }
 
 void fix_FRM_FRF_Material(char* str)
 {
-	if (str[8] == '2' && (strncmp(&str[3], "CH", 2) == 0 || strncmp(&str[3], "LG", 2) == 0)) // Chest or Legs
+	if (str[8] == '2' && (isChest(str) || isLeg(str))) // Chest or Legs
 		str[7] = '0'; // override the Face/Head variant back to zero on Chest 02 and Leg 02
 }
 
@@ -1943,9 +1958,12 @@ int FRM_FRF_ReplaceMaterial(CDisplay* this_ptr, char* OldMaterial, char* NewMate
 	if (OldMaterial)
 		fix_FRM_FRF_Material(OldMaterial);
 
+	if (isWrist(NewMaterial) && isRobe(NewMaterial))
+		return 1; // Robes just hide the wrist but don't display a sleeve, so for now just keep whatever is already on their wrist
+
 	int result = CDisplay__ReplaceMaterial_Trampoline(this_ptr, OldMaterial, NewMaterial, Sprite, pColor, 1);
 
-	if (isRobe(NewMaterial) && NewMaterial[8] == '1')
+	if (isChest(NewMaterial) && isRobe(NewMaterial) && NewMaterial[8] == '1')
 	{
 		char face = NewMaterial[7];
 		char NewLegMaterial[16];

--- a/eqgame_dll/eqgame.h
+++ b/eqgame_dll/eqgame.h
@@ -1,5 +1,7 @@
 //#include "..\zlib_x86\include\zlib.h"
 
+#include <string>
+
 #ifndef PACKET_FUNCTIONS_H
 #define PACKET_FUNCTIONS_H
 
@@ -29,6 +31,33 @@ struct WearChange_Struct
 	/*006*/ unsigned short align06;
 	/*008*/ unsigned int   color;
 };
+
+struct Illusion_Struct
+{
+	unsigned short spawnid;
+	unsigned short race;
+	unsigned char gender;
+	unsigned char texture;
+	unsigned char helmtexture;
+	unsigned char unknown007; // maybe 16-bit helmtexture
+	unsigned short face;
+	unsigned char hairstyle;
+	unsigned char haircolor;
+	unsigned char beard;
+	unsigned char beardcolor;
+	unsigned short unknown_void;
+	int size;
+};
+
+struct RaceData
+{
+	std::string actor_tag = "";
+	std::string animation_fallback_tag = "";
+};
+
+// Custom Race Support
+RaceData* GetCustomRaceData(int race, int gender);
+void PutCustomRaceData(int race, int gender, std::string actor_tag, std::string fallback_anim_actor_tag = "");
 
 // Custom Messaging Support
 constexpr unsigned int SpawnAppearanceType_ClientDllMessage = 256;

--- a/eqgame_dll/eqmac.h
+++ b/eqgame_dll/eqmac.h
@@ -2054,7 +2054,11 @@ typedef struct _EQACTORINFO
 	/* 0x0320 */ BYTE MovementType; // 0 = None, 4 = Walking, 6 = Running, 7 = Swimming
 	/* 0x0321 */ BYTE Unknown0321[12];
 	/* 0x032D */ BYTE IsMovingTimer; // 0 = Moving, 1-6 = Recently Stopped Moving, 200 = Not Moving
-	/* 0x032E */ BYTE Unknown032E[266];
+	/* 0x032E */ BYTE Unknown032E[130];
+	/* 0x03B0 */ BYTE IsLuclinModel;
+	/* 0x03B1 */ BYTE Unknown03B1[115];
+	/* 0x0424 */ DWORD CastingSpellCastTime;
+	/* 0x0428 */ BYTE Unknown0428[16];
 	/* 0x0438 */ DWORD IsLookingForGroup;
 	/* 0x043C */ DWORD IsTrader;
 	/* ...... */


### PR DESCRIPTION
- Many improvements and loading support for froglok/guktan.
- Player frogloks (e.g. Illusion: Froglok) will now use the new classic/guktan assets, and display their armor textures (WIP).
- Added toggle for `UseLuclinFroglok=TRUE/FALSE` (defualt: FALSE)
- Requires updated globalfroglok_chr.s3d and RaceData.txt

Future TODOs / Known Issues
- Add server-side logic to support PC frogloks (such as WearChange events etc). Right now it's purely client-side. So armor doesn't always sync up.
- Guktan robes/armor interactions have minor issues: No sleeves on robes. Equipping leg armor after a robe can overwrite part of the robe, etc.
- Guktans don't show helmets.
- Froglok armor assets are WIP.
- Races in general might need some logic to not bug out when velious armor textures are equipped, depending on what players players are using for velious textures on/off.