### PR TITLE
Cumulative updates for Quarm service pack 2 (Velious dll)

### DIFF
--- a/eqgame_dll/eqgame.cpp
+++ b/eqgame_dll/eqgame.cpp
@@ -4449,6 +4449,12 @@ DWORD CInvSlotMgr_MaxInvSlots = 450; // Set by PatchMaxBankSlots
 DWORD CInvSlotMgr_NumInvSlots_Offset = 0x70C; // Set by PatchMaxBankSlots
 DWORD CInvSlotMgr_LastUpdateTime_Offset = 0x710; // Set by PatchMaxBankSlots
 
+void SharedBank_OnZone()
+{
+	Rule_Shared_Bank_Mode = 0;
+	Rule_Shared_Bank_Slots_Available = 0;
+}
+
 bool SharedBank_HandleMessages(DWORD id, DWORD value, bool is_request)
 {
 	// Server initiates the shared bank negotiation
@@ -5584,6 +5590,7 @@ void InitHooks()
 	// [BigBank/SharedBank]
 	PatchExtraBankSlotSupport();
 	PatchCheckLoreConflict();
+	OnZoneCallbacks.push_back(SharedBank_OnZone);
 	CustomSpawnAppearanceMessageHandlers.push_back(SharedBank_HandleMessages);
 	CInvSlotMgr__UpdateSlots_Trampoline = (EQ_FUNCTION_TYPE_CInvSlotMgr__UpdateSlots)DetourFunction((PBYTE)0x423089, (PBYTE)CInvSlotMgr__UpdateSlots_Detour); // Displays the new slots
 	MoveItem_Trampoline = (EQ_FUNCTION_TYPE_MoveItem)DetourFunction((PBYTE)0x422B1C, (PBYTE)MoveItem_Detour); // Moves items to/from the new slots

--- a/eqgame_dll/eqmac_functions.h
+++ b/eqgame_dll/eqmac_functions.h
@@ -77,6 +77,12 @@ void EQ_WriteMemoryString(DWORD address, const char* value)
 	*(unsigned char*)(address + j) = '\0';
 }
 
+// Read a TRUE/true/1 or FALSE/false/0 boolean from eqclient.ini with the default EQ logic. Sets/Uses defaultValue if not found.
+bool GetEQClientIniFlag_55B947(const char* lpAppName, const char* lpKeyName, char* defaultValue)
+{
+	return reinterpret_cast<bool(__cdecl*)(const char* lpAppName, const char* lpKeyName, char* defaultValue)>(0x55B947)(lpAppName, lpKeyName, defaultValue);
+}
+
 // direct input
 
 //IDirectInput8** EQ_ppIDirectInput8 = (IDirectInput8**)EQ_DINPUT_ROOT;


### PR DESCRIPTION
Shared Bank
- Fixed a bug that allowed modifying the shared bank when the contents didn't load.
- Prevented storing No Rent items in the shared bank. In the future, No Rent items already in the shared bank will be deleted. Remove them now while you can.

Races
- Improved support for Froglok armor appearances.
- Fixes compatibility issues between Luclin models and Velious textures.

Internal Changes
- Made the client set several default .ini values the first time it runs to their recommended values.
- Added support for optional `quarmclient.ini` file. Any ini settings in that file will be applied to eqclient.ini on every launch of the game (forced overrides). This will be supplied by the patcher.
- Added new ini value `UnlockVeliousTextures` that will allow the client to show velious textures (if not already enabled by the server via expansion flag on user accounts).