### PR TITLE
Follow-up tweak for Jam Fest to show correctly on bards too

### DIFF
--- a/eqgame_dll/eqgame.cpp
+++ b/eqgame_dll/eqgame.cpp
@@ -5641,6 +5641,7 @@ void InitHooks()
 
 	// Fix Jam Fest stats desync
 	EQ_Character__HitBySpell_Trampoline = (EQ_FUNCTION_TYPE_EQ_Character__HitBySpell)DetourFunction((PBYTE)0x4C8492, (PBYTE)EQ_Character__HitBySpell_Detour);
+	PatchNopByRange(0x004C65F4, 0x004C65F7); // Fixes Bards double-adding Jam Fest modifier on self (trust server to send correct caster level)
 
 	return_ProcessMouseEvent = (ProcessGameEvents_t)DetourFunction((PBYTE)o_MouseEvents, (PBYTE)ProcessMouseEvent_Hook);
 	//return_SetMouseCenter = (ProcessGameEvents_t)DetourFunction((PBYTE)o_MouseCenter, (PBYTE)SetMouseCenter_Hook);


### PR DESCRIPTION
- Fixes a display bug where Bards could still see Jam Fest applied twice on their stats page.
  - Prevents client from doing the casterLevel logic locally, now just trusts the server for the right casterLevel.
  - Note: `Spells:JamFestAAOnlyAffectsBard` MUST be `false` going forward (as it should be). In which case the server will be trustworthy and sending the correct casterLevels. Since now this assumption is baked in.

Everything should be fully in sync now for both bard and non-bards from what I saw. Apologies this took a follow-up PR.