### PR TITLE
Fixes pvp level range

### DIFF
--- a/eqgame_dll/eqgame.cpp
+++ b/eqgame_dll/eqgame.cpp
@@ -2500,6 +2500,16 @@ void FixBazaarCrash()
 // Bazaar Crash Fix [end]
 // --------------------------------------------------------------------------
 
+// * level_range - Players must be +/- this level range to pvp
+// * pvp_min_level - Players below this level cannot pvp
+void SetPvpLevelRange(BYTE level_range, BYTE pvp_min_level)
+{
+	PatchT(0x509CB2, (BYTE)level_range);
+	PatchT(0x509E03, (BYTE)level_range);
+	PatchT(0x509CBC, (BYTE)pvp_min_level);
+	PatchT(0x509CC6, (BYTE)pvp_min_level);
+}
+
 #define EQZoneInfo_AddZoneInfo 0x00523AEB
 #define EQZoneInfo_AddZoneInfo 0x00523AEB
 
@@ -5698,6 +5708,8 @@ void InitHooks()
 	PatchNopByRange(0x004C65F4, 0x004C65F7); // Fixes Bards double-adding Jam Fest modifier on self (trust server to send correct caster level)
 
 	FixBazaarCrash();
+
+	SetPvpLevelRange(100, 0);
 
 	return_ProcessMouseEvent = (ProcessGameEvents_t)DetourFunction((PBYTE)o_MouseEvents, (PBYTE)ProcessMouseEvent_Hook);
 	//return_SetMouseCenter = (ProcessGameEvents_t)DetourFunction((PBYTE)o_MouseCenter, (PBYTE)SetMouseCenter_Hook);


### PR DESCRIPTION
- Fixes debuffs to show properly when landing in PvP.
  - The client was ignoring (not showing) debuffs cast by PvP players outside of a 4 level range. Causing their buff bar to become out of sync with the server.
  - We may want to bump the DLL_VERSION and required version check for access to pvp zones to make sure everyone is running this update.

